### PR TITLE
Changes in HtmlFetcher to extract the html string 

### DIFF
--- a/src/main/java/de/jetwick/snacktory/FetchResult.java
+++ b/src/main/java/de/jetwick/snacktory/FetchResult.java
@@ -1,0 +1,50 @@
+package de.jetwick.snacktory;
+
+import java.io.InputStream;
+
+public class FetchResult {
+
+    private String url;
+    private InputStream pageInputStream;
+    private String contentType;
+    private String htmlAsString;
+    
+    public FetchResult(){
+        
+    }
+    
+    public FetchResult(String url, InputStream pageInputStream, String contentType,String res) {
+        this.url = url;
+        this.pageInputStream = pageInputStream;
+        this.contentType = contentType;
+        this.htmlAsString = res;
+    }
+    
+    public String getUrl() {
+        return url;
+    }
+    public void setUrl(String url) {
+        this.url = url;
+    }
+    public InputStream getPageInputStream() {
+        return pageInputStream;
+    }
+    public void setPageInputStream(InputStream pageInputStream) {
+        this.pageInputStream = pageInputStream;
+    }
+    public String getContentType() {
+        return contentType;
+    }
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getHtmlAsString() {
+        return htmlAsString;
+    }
+
+    public void setHtmlAsString(String htmlAsString) {
+        this.htmlAsString = htmlAsString;
+    }
+    
+}

--- a/src/main/java/de/jetwick/snacktory/HtmlFetcher.java
+++ b/src/main/java/de/jetwick/snacktory/HtmlFetcher.java
@@ -357,8 +357,11 @@ public class HtmlFetcher {
             hConn.setRequestMethod("HEAD");
             hConn.connect();
             responseCode = hConn.getResponseCode();
-            hConn.getInputStream().close();
-            if (responseCode == HttpURLConnection.HTTP_OK)
+            try {
+				hConn.getInputStream().close();
+			} catch (Exception e) {
+			}
+			if (responseCode == HttpURLConnection.HTTP_OK)
                 return urlAsString;
 
             newUrl = hConn.getHeaderField("Location");

--- a/src/main/java/de/jetwick/snacktory/HtmlFetcher.java
+++ b/src/main/java/de/jetwick/snacktory/HtmlFetcher.java
@@ -410,8 +410,8 @@ public class HtmlFetcher {
             hConn.setRequestMethod("HEAD");
             hConn.connect();
             responseCode = hConn.getResponseCode();
-			hConn.getInputStream().close();
-			if (responseCode == HttpURLConnection.HTTP_OK)
+            hConn.getInputStream().close();
+            if (responseCode == HttpURLConnection.HTTP_OK)
                 return urlAsString;
 
             newUrl = hConn.getHeaderField("Location");


### PR DESCRIPTION
@dmorgan-github couple of changes in this module too :
- No change in existing snacktory code, except the user-agent change.
- Added new function **fetchHtmlString** which is same as existing **fetchAsString** to customize the output.
also added one pojo FetchResult to get the same output.
- Added new function **getResolvedConnection** which is functionally same as **getResolvedUrl** to get the moved url **to keep the connection object same**.
- Can we bump the pom version to implement this change?